### PR TITLE
Use TurboWarp for Autoplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,26 @@
 <html>
-  <head> 
+  <head>
     <title>Tonka</title>
-   </head>
-   <body>
+  </head>
+  <body>
     <h1>Tonka</h1>
     <p>
-        This is a scratch project that (very slowly) draws the Mandelbrot set.
-        Click the green flag to start. By clicking on the green flag again with the shift button pressed will enable Turbo Mode.
-        You might want that, because without it the cat is so slow, it might as well invoke 7 compilation steps to calculate each pixel.
-        Use the feature at your own discretion.
-        If you have any idea on how to auto-start the embedding, please let me know.
+      This is a scratch project that (very slowly) draws the Mandelbrot set.
+      Click the green flag to start. By clicking on the green flag again with
+      the shift button pressed will enable Turbo Mode. You might want that,
+      because without it the cat is so slow, it might as well invoke 7
+      compilation steps to calculate each pixel. Use the feature at your own
+      discretion.
     </p>
-    <iframe src="https://scratch.mit.edu/projects/1101388148/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>
-    <p>
-        by styrix560
-    </p>
-   </body>
+    <iframe
+      src="https://turbowarp.org/1101388148/embed?autoplay"
+      allowtransparency="true"
+      width="482"
+      height="412"
+      frameborder="0"
+      scrolling="no"
+      allowfullscreen
+    ></iframe>
+    <p>by styrix560</p>
+  </body>
 </html>


### PR DESCRIPTION
The Scratch website does not support autoplay functionality, so I used [TurboWarp](https://turbowarp.org/), a modified Scratch player that provides better performance and additional customization options. One of these options is [autoplay](https://docs.turbowarp.org/embedding#url-parameters), which I enabled by adding it as a URL parameter.

Notice, that the code was automatically formatted by Prettier. If you'd prefer not to include these formatting changes, let me know, and I can revert them.